### PR TITLE
fix(ie11) currently the target node 4 producers template literals

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,5 +1,11 @@
 {
   "presets": [
-    ["@babel/preset-env", { "targets": { "node": "4" } }]
+    ["@babel/preset-env", {
+      "targets": {
+        "node": "4",
+        "chrome": "58",
+        "ie": "11"
+      }
+    }]
   ]
 }


### PR DESCRIPTION
which isn't supported by ie11, by changing the target it supports both without drastically affecting build size